### PR TITLE
Simplifier l'envoi d'image

### DIFF
--- a/Server/src/protocol.c
+++ b/Server/src/protocol.c
@@ -233,7 +233,7 @@ unsigned int send_picture(int sockfd, FILE *fp, char *buffer) {
     if (rem > 0) {
         explicit_bzero(buffer, BUFFER_SIZE);
         fread(buffer, sizeof(char), rem, fp);
-        bytes_sent = send_msg("[pic] ", sockfd, buffer, BUFFER_SIZE);
+        bytes_sent = send_msg("[pic] ", sockfd, buffer, rem);
         total_bytes_sent += bytes_sent;
     }
     fprintf(stdout,"[pic] Sent %d picture bytes\n", total_bytes_sent);

--- a/Server/src/protocol.c
+++ b/Server/src/protocol.c
@@ -185,22 +185,9 @@ void *img_task(void *ptr) {
             char *fname = "/home/pi/pic.jpg";
             FILE *file_handle = fopen(fname, "r");
             send_picture(img_client_sockfd, file_handle, buffer);
-            explicit_bzero(cmd, CMD_LEN);
-            read_msg("[pic] ", img_client_sockfd, buffer, cmd, BUFFER_SIZE);
-            fprintf(stdout, "[pic] Message received: %s\n", cmd);
-            while (strncmp(cmd, "RESEND_PICTURE", CMD_LEN) == 0) {
-                send_picture(img_client_sockfd, file_handle, buffer);
-                explicit_bzero(cmd, CMD_LEN);
-                read_msg("[pic] ", img_client_sockfd, buffer, cmd, BUFFER_SIZE);
-                fprintf(stdout, "[pic] Message received: %s\n", cmd);
-            }
-            if (strncmp(cmd, "RECEIVED_OK", CMD_LEN) == 0) {
-                fprintf(stdout, "Client received picture at %s\n", fname);
-            } else {
-                fprintf(stderr, "Invalid Client response: %s\n", cmd);
-            }
             fclose(file_handle);
             shutdown_socket("pic", "image client", img_client_sockfd);
+            explicit_bzero(cmd, CMD_LEN);
         }
     }
     fprintf(stdout, "[pic] Client disconnected\n");


### PR DESCRIPTION
Le serveur envoie les bytes de l'image, puis ferme le socket. C'est la responsabilité du client de redemander une image via la commande `PICTURE`